### PR TITLE
Token type vocab shape changed

### DIFF
--- a/convert_jax_checkpoint.py
+++ b/convert_jax_checkpoint.py
@@ -104,7 +104,7 @@ def main(args):
         'embedding_size': encoder['embedder']['word']['embedding'].shape[1],
         'intermediate_size': encoder['feed_forward_0']['intermediate']['bias'].shape[0],
         'max_position_embeddings': encoder['embedder']['position']['embedding'].shape[1],
-        'type_vocab_size': encoder['embedder']['type']['embedding'].shape[1],
+        'type_vocab_size': encoder['embedder']['type']['embedding'].shape[0],
         'fourier': 'fft',
         'pad_token_id': tokenizer.pad_id(),
         # https://github.com/google-research/google-research/blob/master/f_net/models.py#L43

--- a/convert_jax_checkpoint.py
+++ b/convert_jax_checkpoint.py
@@ -109,7 +109,7 @@ def main(args):
         'type_vocab_size': 4,
         # https://github.com/google-research/google-research/blob/master/f_net/models.py#L43
         'layer_norm_eps': 1e-12,
-        'hidden_dropout_prob': 0.1,
+        'dropout_rate': 0.1,
         'num_hidden_layers': num_layers
     }
 

--- a/fnet.py
+++ b/fnet.py
@@ -14,7 +14,7 @@ class FNetEmbeddings(nn.Module):
 
         self.layer_norm = nn.LayerNorm(config['embedding_size'], eps=config['layer_norm_eps'])
         self.hidden_mapping = nn.Linear(config['embedding_size'], config['hidden_size'])
-        self.dropout = nn.Dropout(config['hidden_dropout_prob'])
+        self.dropout = nn.Dropout(config['dropout_rate'])
 
         self.register_buffer(
             'position_ids',
@@ -74,7 +74,7 @@ class FNetLayer(nn.Module):
         self.feed_forward = nn.Linear(config['hidden_size'], config['intermediate_size'])
         self.output_dense = nn.Linear(config['intermediate_size'], config['hidden_size'])
         self.output_layer_norm = nn.LayerNorm(config['hidden_size'], eps=config['layer_norm_eps'])
-        self.dropout = nn.Dropout(config['dropout_prob'])
+        self.dropout = nn.Dropout(config['dropout_rate'])
         self.activation = nn.GELU()
 
     def forward(self, hidden_states):

--- a/fnet.py
+++ b/fnet.py
@@ -74,6 +74,7 @@ class FNetLayer(nn.Module):
         self.feed_forward = nn.Linear(config['hidden_size'], config['intermediate_size'])
         self.output_dense = nn.Linear(config['intermediate_size'], config['hidden_size'])
         self.output_layer_norm = nn.LayerNorm(config['hidden_size'], eps=config['layer_norm_eps'])
+        self.dropout = nn.Dropout(config['dropout_prob'])
         self.activation = nn.GELU()
 
     def forward(self, hidden_states):
@@ -82,6 +83,7 @@ class FNetLayer(nn.Module):
         intermediate_output = self.feed_forward(fft_output)
         intermediate_output = self.activation(intermediate_output)
         output = self.output_dense(intermediate_output)
+        output = self.dropout(output)
         output = self.output_layer_norm(output + fft_output)
         return output
 


### PR DESCRIPTION
Hi mate,
found another small issue now, `convert_jax_checkpoint.py`, line 107:
instead of 
`'type_vocab_size': encoder['embedder']['type']['embedding'].shape[1]` 
we need
`'type_vocab_size': encoder['embedder']['type']['embedding'].shape[0]`

